### PR TITLE
a handy way to up and down with docker compose (plus static volume)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
     ports:
-      - "3000"
+      - "3333:3333"
     volumes:
       - ./static:/app/static
     command: python3 -c "import localserver.main; localserver.main.start()"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  codesphera:
+    image: ghcr.io/iamgreggarcia/codesherpa:latest
+    build:
+      context: .
+    ports:
+      - "3000"
+    volumes:
+      - ./static:/app/static
+    command: python3 -c "import localserver.main; localserver.main.start()"


### PR DESCRIPTION
A `docker-compose.yml` is a handy and standard way to manage containers.  This PR adds it which makes starting/stopping the container a breeze with just `docker compose up` command (no need to provide lengthy arguments). 
I hope you find it useful.
This PR also adds local `static` dir on host as a mounted volume to persist generated data between restarts.

Let me know if you'd like me to add it to README.md as well.