### PR TITLE
Clean up apt-get lists in Dockerfile after installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:22.04
 
 # Update and install necessary compilers/interpreters
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     python3.10 \
     python3-pip \
     g++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,15 @@ WORKDIR /app
 
 COPY ./pyproject.toml ./poetry.lock* /app/
 
-RUN pip install poetry
+RUN pip install --no-cache-dir poetry
 
 # Create virtual environment and install dependencies
 RUN poetry config virtualenvs.in-project true && \
     poetry install --no-dev --no-root
 
-RUN /app/.venv/bin/pip install pytest pytest-cov pytest-asyncio
+RUN /app/.venv/bin/pip install --no-cache-dir pytest pytest-cov pytest-asyncio
 
-RUN /app/.venv/bin/pip install google-cloud-secret-manager 
+RUN /app/.venv/bin/pip install --no-cache-dir google-cloud-secret-manager 
 
 RUN mkdir -p /app/static/images
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y \
     make \
     git \
     gnupg \
-    lsb-release
+    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a symbolic link for Python
 RUN ln -s /usr/bin/python3.10 /usr/bin/python


### PR DESCRIPTION
Every steps in this PR makes the Docker image smaller! Would also make the image build process a little bit faster!

From original 1.17GB -> 1.06GB:


```sh
$ docker images
REPOSITORY          TAG                  IMAGE ID       CREATED          SIZE
version4            latest               4dc71e1dd567   7 minutes ago    1.06GB
version3            latest               29f0698ad5b7   12 minutes ago   1.1GB
version2            latest               f9f6e665dfa8   27 minutes ago   1.13GB
version1            latest               23443eda8719   34 minutes ago   1.17GB
```